### PR TITLE
Mofo eoy 2016 QA, adding button color option and fixing spacing issues.

### DIFF
--- a/campaigns/mofo-eoy-2016/snippet.html
+++ b/campaigns/mofo-eoy-2016/snippet.html
@@ -8,7 +8,7 @@ Variables:
   @button_label: Required. Text for donate button.
   @donation_form_url: Required. Url to the donation form.
 
-  @button_color: Default blue. Red and green also options.
+  @button_color: Default blue. Red, green and gray are also options.
 
   @locale: Default en-US. String for the locale code.
   @currency_code: Default usd. The code for the currency. Examle gbp, cad, usd.
@@ -27,7 +27,7 @@ Variables:
 #}
 <style>
   #snippetContainer div.snippet img.icon {
-    margin: 2px 8px 5px 0;
+    margin: 0 8px 0 0;
     float: none;
   }
 
@@ -84,6 +84,17 @@ Variables:
   .button-link:hover {
     background: #BEE8D7;
   }
+{% elif button_color == "gray" %}
+
+  .button-link {
+    background: #D5DADE;
+    color: #3C3C3C;
+  }
+
+  .button-link:hover {
+    background: rgba(213, 218, 222, .6);
+    color: #3C3C3C;
+  }
 {% else %}
 
   .button-link {
@@ -127,6 +138,7 @@ Variables:
 
   .donation-amounts {
     overflow: hidden;
+    margin-top: 5px;
   }
 {% if small_buttons %}
 


### PR DESCRIPTION
@glogiotatidis Hey, a few things were found/requested in the 2016 fundraising snippet.

There is a bit of spacing issues in the test without the icon, and I am missed the grey button option, which was requested.

The spacing issue is this: 
![unnamed](https://cloud.githubusercontent.com/assets/197334/19365053/d7746d14-915e-11e6-964f-79718758b515.png)

It turns out the margin was on the icon bottom, which also isn't great in and of itself. When the icon is gone, we lost that margin, then if the text went to more than two lines, it hit the buttons. So I removed the bottom 5px margin on the icon, and instead applied it to the top of the buttons. Seems to work better.

Thoughts?