### PR TITLE
EOY 2016 fundraising snippet opt out changes.

### DIFF
--- a/campaigns/mofo-eoy-2016/snippet.html
+++ b/campaigns/mofo-eoy-2016/snippet.html
@@ -38,6 +38,7 @@ Variables:
   @special_image_fifth: Optional. Replace a few of the background images with special images.
 
   @blockable: checkbox - Check to allow user to block this snippet.
+  @auto_blockable: checkbox - Auto block once the user interacts. Defaults to true.
   @block_button_text - small text - Text to display while hovering over opt out button. Default "Remove this"
 
 #}
@@ -472,16 +473,19 @@ Variables:
 
     snippet.addEventListener("show_snippet", function () {
         var btnDonate = snippet.querySelector(".button-link");
-        btnDonate.addEventListener("click", function(event) {
-            if (!btnDonate.getAttribute("disabled")) {
-                event.preventDefault();
-                event.stopPropagation();
-                btnDonate.setAttribute("disabled", "disabled");
-                addToBlockList();
-                // Give some time to IndexedDB. Bug 1236090
-                setTimeout(function() { btnDonate.click() }, 500);
-            }
-        });
+      {% if blockable and auto_blockable != false %}
+        function clickEvent(event) {
+          if (event.button === 0 && !(event.metaKey || event.ctrlKey)) {
+            event.preventDefault();
+            event.stopPropagation();
+            btnDonate.removeEventListener("click", clickEvent);
+            addToBlockList();
+            // Give some time to IndexedDB. Bug 1236090
+            setTimeout(function() { event.target.click(); }, 500);
+          }
+        }
+        btnDonate.addEventListener("click", clickEvent);
+      {% endif %}
 
         {% if background_image %}
           var body = document.querySelector("body");


### PR DESCRIPTION
@glogiotatidis thoughts?

Few tweaks.

1. Wes noticed ctrl+click no longer opened in a new tab. I fixed that by copying code right from the snippet service.
2. I'm adding and removing the event now instead of checking against the `disabled` attribute.
3. I added a flag to turn the opt out on click feature on and off. There is possibly an open discussion around this, and I wouldn't mind being flexible here. By default it should work like it is now.
