### PR TITLE
Hide success and error msg on back button click.

### DIFF
--- a/generic-templates/newsletter-signup-snippet/snippet.html
+++ b/generic-templates/newsletter-signup-snippet/snippet.html
@@ -465,6 +465,8 @@ Variables:
           }
           currentIndex--;
           transitionTrack.style.transform = "translate(-" + ( currentIndex * trackItemWidth ) + "px, 0px)";
+          basketError.classList.add("hidden");
+          successMessage.classList.add("hidden");
         }
 
         for (var nextIndex = 0; nextIndex < nextButtons.length; nextIndex++) {


### PR DESCRIPTION
Basket error and success messages persist if you click the back button. Fix this. 

@ScottDowne r?