### PR TITLE
Signup snippet fixing submit bug and UX change on error.

### DIFF
--- a/generic-templates/newsletter-signup-snippet/snippet.html
+++ b/generic-templates/newsletter-signup-snippet/snippet.html
@@ -382,13 +382,17 @@ Variables:
         var basketError = snippet.querySelector(".basket-error");
         var successMessage = snippet.querySelector(".success-message");
 
-        document.querySelector("#form").addEventListener("submit", function(e) {
-          e.preventDefault();
+        function submit() {
           if (button.classList.contains("loading")) {
             return;
           }
           changeState(000);
           sendEmailToBasket();
+        }
+
+        document.querySelector("#form").addEventListener("submit", function(e) {
+          e.preventDefault();
+          submit();
         });
 
         function sendEmailToBasket() {
@@ -434,8 +438,9 @@ Variables:
         var transitionTrack = snippet.querySelector(".transition-track");
         var trackItemWidth = 420;
         var currentIndex = 0;
+        var numberOfTabs = 2;
 
-        emailInput.addEventListener("click", function() {
+        emailInput.addEventListener("input", function() {
           emailInput.classList.remove("invalid");
         });
 
@@ -447,12 +452,15 @@ Variables:
         });
 
         function onNext() {
-          if (currentIndex >= 2) {
+          if (currentIndex >= numberOfTabs - 1) {
+            // If we're at the last tab, try submitting.
+            submit();
             return;
           }
           if (currentIndex === 0) {
             if (!emailInput.checkValidity()) {
               emailInput.classList.add("invalid");
+              emailInput.focus();
               return;
             }
           }
@@ -487,3 +495,4 @@ Variables:
  })();
  //]]>
 </script>
+


### PR DESCRIPTION
@glogiotatidis Jean found this bug. `onNext` wasn't actually smart enough to call submit.

I'm thinking we make a check in `onNext` so if it's on the last tab, it does a submit. Thoughts?

I also noticed the UX of an error state was kinda weird. If I click the button and it triggers an error, we might as well refocus the email, and clear the email box error state when the user starts typing again. Slightly better UX.